### PR TITLE
Update TDX Libvirt XML template

### DIFF
--- a/tools/cvm-image-rewriter/tdx-libvirt-ubuntu-host.xml.template
+++ b/tools/cvm-image-rewriter/tdx-libvirt-ubuntu-host.xml.template
@@ -1,9 +1,6 @@
 <domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
   <name>tdx-guest</name>
   <memory unit='GiB'>REPLACE_MEM_SIZE</memory>
-  <memoryBacking>
-    <source type='memfd-private'/>
-  </memoryBacking>
   <vcpu placement="static">REPLACE_VCPU_NUM</vcpu>
   <os>
     <type arch='x86_64' machine='q35'>hvm</type>


### PR DESCRIPTION
Remove memfd-private to align with TDX early preview version.