### PR TITLE
Update scripts for easy deployment from scratch

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -98,6 +98,9 @@ function build_a_image {
     cd "${top_dir}"
     if [[ -n "${docker_build_clean_param}" ]]; then
         docker build \
+             --build-arg http_proxy \
+             --build-arg https_proxy \
+             --build-arg no_proxy \
              --build-arg pip_mirror \
              -f container/"${1}"/Dockerfile \
              . \
@@ -106,6 +109,9 @@ function build_a_image {
              { echo "Fail to build docker ${registry}/${1}:${tag}"; exit 1; }
     else
         docker build \
+             --build-arg http_proxy \
+             --build-arg https_proxy \
+             --build-arg no_proxy \
              --build-arg pip_mirror \
              -f container/"${1}"/Dockerfile \
              . \

--- a/deployment/docker-compose/prerequisite.sh
+++ b/deployment/docker-compose/prerequisite.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e
+
+DIR=$(dirname "$(readlink -f "$0")")
+
+# shellcheck disable=SC1091
+. "$DIR"/scripts/cache.sh
+check_cache_dir
+ok "Cache Dir Clear"
+
+# shellcheck disable=SC1091
+. "$DIR"/scripts/device.sh
+grant_dev_tdx
+ok "Dev TDX Valid"
+
+info "Make Sure Service QGS&PCCS is Avaliable to Get Quote"
+
+
+function install_docker {
+    echo "========= Install Docker ==========="
+    # install GPG key
+    install -m 0755 -d /etc/apt/keyrings
+    rm -f /etc/apt/keyrings/docker.gpg
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    chmod a+r /etc/apt/keyrings/docker.gpg
+
+    # install repo
+    # shellcheck disable=SC1091
+    echo \
+    "deb [arch=\"$(dpkg --print-architecture)\" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+    tee /etc/apt/sources.list.d/docker.list > /dev/null
+    apt-get update > /dev/null
+
+    # install docker
+    apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+    # start docker
+    systemctl enable docker
+    systemctl daemon-reload
+    systemctl start docker
+}
+
+if command -v docker &> /dev/null; then
+    echo "Skip: Docker has been installed."
+else
+    install_docker
+fi
+

--- a/tools/cvm-image-rewriter/cloud-init/user-data.basic
+++ b/tools/cvm-image-rewriter/cloud-init/user-data.basic
@@ -23,6 +23,6 @@ runcmd:
   - update-grub
 
 # Uncomment this section if you plan to change user/password
-# user: tdx
-# password: 123456
-# chpasswd: { expire: False }
+user: tdx
+password: 123456
+chpasswd: { expire: False }

--- a/tools/cvm-image-rewriter/qemu-test.sh
+++ b/tools/cvm-image-rewriter/qemu-test.sh
@@ -37,8 +37,8 @@ else
 fi
 
 # VM configurations
-CPUS=1
-MEM=4G
+CPUS=4
+MEM=16G
 SGX_EPC_SIZE=64M
 
 OVMF="/usr/share/qemu/OVMF.fd"


### PR DESCRIPTION
1. qemu-test.sh: Enlarge default cpu and memory to meet CCNP deployment needs.
2. Rename docker-compose depployment prepare.sh to prerequisite.sh to keep align with k8s deployment scripts.
3. Add proxy back in build.sh
4. Enable user/password setting by default in case user use official cloud image.