### PR TITLE
Plugin 06: not use interactive installation

### DIFF
--- a/tools/cvm-image-rewriter/plugins/06-install-tdx-guest-kernel/pre-stage/host_run.sh
+++ b/tools/cvm-image-rewriter/plugins/06-install-tdx-guest-kernel/pre-stage/host_run.sh
@@ -40,8 +40,9 @@ cat > "${CURR_DIR}/../cloud-init/x-shellscript/07-install-tdx-guest-kernel.sh" <
 
 PACKAGE_DIR=""$ARTIFACTS_GUEST"/$(basename "$CVM_TDX_GUEST_REPO")/"
 pushd \$PACKAGE_DIR || exit 0
-apt install ./linux-image-unsigned-*.deb ./linux-modules-*.deb \
-        ./linux-headers-*.deb ./linux-intel-opt-headers-*.deb --allow-downgrades -y
+DEBIAN_FRONTEND=noninteractive apt install ./linux-image-unsigned-*.deb \
+./linux-modules-*.deb ./linux-headers-*.deb \
+./linux-intel-opt-headers-*.deb --allow-downgrades -y 
 popd || exit 0
 EOL
 


### PR DESCRIPTION
When the default kernel big version of CVM guest image is the same as the one to be installed, it will hang due to the interactive warning. This change will skip interactive warning and make sure the new kernel will be installed.