### PR TITLE
deployment: remove grpc-health-probe check for false alarm

### DIFF
--- a/container/ccnp-server/Dockerfile
+++ b/container/ccnp-server/Dockerfile
@@ -6,12 +6,6 @@ RUN apk update \
 COPY service/ccnp-server /ccnp-server
 RUN cd /ccnp-server && make build
 
-# add rediness and liveness probe command
-WORKDIR /usr/bin
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.22 && \
-    wget -qO grpc-health-probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x grpc-health-probe
-
 # ======================================================================================================================
 
 From alpine:3.17
@@ -27,7 +21,6 @@ RUN addgroup -S -g $GID $GROUP \
 
 COPY --from=ccnp-server-builder /ccnp-server/target/release/ccnp_server /usr/bin
 COPY --from=ccnp-server-builder /ccnp-server/configs/policy.yaml /etc
-COPY --from=ccnp-server-builder /usr/bin/grpc-health-probe /usr/bin
 
 USER $UID
 CMD ["/usr/bin/ccnp_server", "-p", "/etc/policy.yaml"]

--- a/deployment/kubernetes/charts/ccnp-server/templates/daemonset.yaml
+++ b/deployment/kubernetes/charts/ccnp-server/templates/daemonset.yaml
@@ -33,17 +33,6 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
 {{- end }}
-          livenessProbe:
-            exec:
-              command: ["/usr/bin/grpc-health-probe", "-addr=unix:/run/ccnp/uds/ccnp-server.sock"]
-            initialDelaySeconds: 10
-            periodSeconds: 10
-          readinessProbe:
-            exec:
-              command: ["/usr/bin/grpc-health-probe", "-addr=unix:/run/ccnp/uds/ccnp-server.sock"]
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            failureThreshold: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/deployment/kubernetes/manifests/ccnp-server-deployment.yaml
+++ b/deployment/kubernetes/manifests/ccnp-server-deployment.yaml
@@ -26,17 +26,6 @@ spec:
       - name: ccnp-server
         image: docker.io/library/ccnp-server:latest
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          exec:
-            command: ["/usr/bin/grpc-health-probe", "-addr=unix:/run/ccnp/uds/ccnp-server.sock"]
-          initialDelaySeconds: 10
-          periodSeconds: 10
-        readinessProbe:
-          exec:
-            command: ["/usr/bin/grpc-health-probe", "-addr=unix:/run/ccnp/uds/ccnp-server.sock"]
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          failureThreshold: 10
         resources:
           limits:
             tdx.intel.com/tdx-guest: 1

--- a/sdk/rust/example/src/rust-sdk-example.rs
+++ b/sdk/rust/example/src/rust-sdk-example.rs
@@ -1,7 +1,7 @@
 use cctrusted_base::api::*;
 use cctrusted_base::api_data::*;
 use cctrusted_base::cc_type::TeeType;
-// use cctrusted_base::tcg::EventLogEntry;
+use cctrusted_base::tcg::EventLogEntry;
 use cctrusted_base::tcg::TcgAlgorithmRegistry;
 use cctrusted_base::tdx::quote::TdxQuote;
 use ccnp::sdk::API;
@@ -160,13 +160,13 @@ fn get_cc_eventlog() {
     //     eventlog.show();
     // }
 
-    /*
     // retrieve cc eventlog in batch
-    info!("call cc trusted API [get_cc_eventlog] to get container related eventlog in batch size of 10!");
+    info!("call cc trusted API [get_cc_eventlog] to get container related eventlog in 10 batches!");
     let mut eventlogs2: Vec<EventLogEntry> = Vec::new();
     let mut start = 0;
-    let batch_size = 10;
+    let batch_size = (eventlogs1.len() / 10) as u32;
     loop {
+        info!("batch start: {}", start);
         let event_logs = match API::get_cc_eventlog(Some(start), Some(batch_size)) {
             Ok(q) => q,
             Err(e) => {
@@ -185,7 +185,6 @@ fn get_cc_eventlog() {
     }
 
     info!("event log count: {}", eventlogs2.len());
-    */
 
     // replay cc eventlog with API "replay_cc_eventlog"
     info!("call cc trusted API [replay_cc_eventlog] to replay container related eventlog!");


### PR DESCRIPTION
- `grpc-health-probe` sometimes gets timeout when heavy traffic, the service will be killed with exit code 137, remove this check.
- revert the test in the example code.