### PR TITLE
deployment: add configfs-tsm support for ccnp-server

### DIFF
--- a/deployment/kubernetes/manifests/ccnp-server-deployment.yaml
+++ b/deployment/kubernetes/manifests/ccnp-server-deployment.yaml
@@ -29,6 +29,10 @@ spec:
         resources:
           limits:
             tdx.intel.com/tdx-guest: 1
+        securityContext:
+          privileged: true
+          runAsGroup: 0
+          runAsUser: 0
         volumeMounts:
           - name: proc
             mountPath: /proc
@@ -40,6 +44,8 @@ spec:
             mountPath: /run/kernel/security/
           - name: vsock-port
             mountPath: /etc/tdx-attest.conf
+          - name: configfs
+            mountPath: /sys/kernel/config/
       volumes:
         - name: proc
           hostPath:
@@ -61,5 +67,9 @@ spec:
           hostPath:
             path: /etc/tdx-attest.conf
             type: File
+        - name: configfs
+          hostPath:
+            path: /sys/kernel/config/
+            type: Directory
       nodeSelector:
         intel.feature.node.kubernetes.io/tdx-guest: "enabled"


### PR DESCRIPTION
Since this is a file-based system, there's always a chance that an operation may fail with a permission error. By default, the TSM system requires root access.